### PR TITLE
hotfix/v0.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can confirm installation via `conda list`
 (figshare_patrons) $ conda list requiam
 ```
 
-You should see that the version is `0.16.4`.
+You should see that the version is `0.16.5`.
 
 ### Configuration Settings
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Currently, there are two GitHub Action workflows:
 A list of released features and their issue number(s).
 List is sorted from moderate to minor revisions for reach release.
 
-v0.16.0 - v0.16.4:
+v0.16.0 - v0.16.5:
  * Merge `grouper_admin` and `grouper_query` modules #87
  * Complete adoption of f-strings #118
  * New pull request templates #120
@@ -303,6 +303,7 @@ v0.16.0 - v0.16.4:
  * Minor: Update bug report template #131
  * Update URLs for organization migration #132
  * Bug: Argument parsing does not properly handle integer input for comparison #143
+ * Bug: int vs float parsing for Grouper settings #150
 
 v0.15.0 - v0.15.1:
  * GitHub actions for CI #105

--- a/requiam/__init__.py
+++ b/requiam/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.4"
+__version__ = "0.16.5"
 
 
 class TimerClass(object):

--- a/requiam/grouper.py
+++ b/requiam/grouper.py
@@ -186,7 +186,7 @@ class Grouper:
         try:
             group_df = pd.DataFrame(result['WsFindGroupsResults']['groupResults'])
 
-            df_query = group_df.loc[group_df['displayExtension'] == group]
+            df_query = group_df.loc[group_df['displayExtension'] == str(group)]
 
             status = True if not df_query.empty else False
             return status

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fr:
 
 setup(
     name='requiam',
-    version='v0.16.4',
+    version='v0.16.5',
     packages=['requiam'],
     url='https://github.com/UAL-ODIS/ReQUIAM',
     license='MIT License',


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a PR without creating an issue first. -->

<!-- Fields in **bold** are REQUIRED, fields in *italics* are OPTIONAL. -->

**Description**
<!-- A description of how this PR resolved the specified bug-->
This is a one-line fix to ensure that Grouper `group` is always provided as a str in Grouper's check_group_exists. This probably could have been fixed by static types (not ready yet). For quick deployment, this should do.

<!-- Add any linked issue(s) -->
Fixes #150


**Update Changelog**
<!-- Be brief, use imperative mood or simple noun phrases and add linked issues -->
<!-- Examples: Improve verbosity of log messages #103 | GitHub actions for CI #105 -->

- [x] README.md, [changelog](../../README.md#changelog) <!-- update changelog here -->


**Bump version**

v0.16.4 -> v0.16.5

- [x] README.md, [installation instructions](../../README.md#installation-instructions)
- [x] [`setup.py`](../../setup.py)
- [x] [`requiam/__init__.py`](../../requiam/__init__.py)


*Screenshots or additional context*
<!-- Add any other context about the problem here and/or screenshots to help explain the problem. -->


*Testing (if applicable)*
<!-- Explain how you tested this bug fix so that others can replicate it. -->
<!-- Example: The exact commands you ran and their output. -->
